### PR TITLE
Allow multiple instances of 'oom'.

### DIFF
--- a/source/cowcomp.cpp
+++ b/source/cowcomp.cpp
@@ -212,9 +212,9 @@ bool compile( int instruction, bool advance )
     
     // oom
     case 11:
-        fprintf( output, "char b[100];int c=0;" );
+        fprintf( output, "{char b[100];int c=0;" );
         fprintf( output, "while(c<sizeof(b)-1){b[c]=getchar();c++;b[c]=0;if(b[c-1]=='\\n')break;}" );
-        fprintf( output, "if(c==sizeof(b))while(getchar()!='\\n');(*p)=atoi(b);" );
+        fprintf( output, "if(c==sizeof(b))while(getchar()!='\\n');(*p)=atoi(b);}" );
         PRETTY( "oom" );
         break;
 


### PR DESCRIPTION
The implementation of 'oom' creates a local array. If multiple 'oom'
statements are present, cowcomp tries to create multiple instances of
this array with the same name. We correct this by creating a new scope
block for the generated output of 'oom'.